### PR TITLE
Replacing tabs by 4 spaces

### DIFF
--- a/app/models/topology.rb
+++ b/app/models/topology.rb
@@ -37,7 +37,7 @@ class Topology < ActiveRecord::Base
 
   def graph=(graph)
     if graph.is_a?(String)
-      super YAML::load(graph.gsub(/\t/, '    '))
+      super YAML.load(graph.gsub(/\t/, '    '))
     else
       super graph
     end

--- a/app/models/topology.rb
+++ b/app/models/topology.rb
@@ -37,7 +37,7 @@ class Topology < ActiveRecord::Base
 
   def graph=(graph)
     if graph.is_a?(String)
-      super YAML::load(graph)
+      super YAML::load(graph.gsub(/\t/, '    '))
     else
       super graph
     end

--- a/spec/controllers/topologies_controller_spec.rb
+++ b/spec/controllers/topologies_controller_spec.rb
@@ -25,6 +25,23 @@ RSpec.describe TopologiesController do
     end
   end
 
+  describe "creating a topology with hard tabs" do
+    let!(:sign_in_user){ sign_in(:user, user) }
+    let(:perform_post){
+      post :create, "topology" =>{
+        "name"=>"Liander testen met Hans",
+        "public"=>"false",
+        "graph"=>"---\r\nname: \"UHV Network\"\r\nstakeholder: system operator\r\nchildren:\r\n- name: \"HV network 150_kV\"\r\n  units: 54\r\n  stakeholder: system operator\r\n  capacity: 208000\r\n  children:\r\n  - name:  \"MS klanten van 150 kV\"\r\n\tunits: 213\r\n\tcapacity: 1000 \r\n\tstakeholder: customer\r\n  - name: \"MSR van 150_kV\"\r\n\tunits: 759\r\n\tstakeholder: system operator\r\n\tcapacity: 417\r\n\tchildren:\r\n\t- name: \"huishoudens van 150_kV\"\r\n\t  units: 61\r\n\t  stakeholder: customer\r\n    - name: \"bedrijven van 150 kV\"\r\n\t  units: 3\r\n\t  stakeholder: customer \r\n- name: \"HV network 110_kV\"\r\n  units: 14\r\n  stakeholder: system operator\r\n  capacity: 95000\r\n  children:\r\n  - name: \"MS klanten van 110 kV\"\r\n\tunits: 97\r\n\tcapacity: 1000\r\n\tstakeholder: customer \r\n  - name: \"MSR van 110_kV\"\r\n\tunits: 346\r\n\tstakeholder: system operator\r\n\tcapacity: 417\r\n\tchildren:\r\n\t- name: \"huishoudens van 110_kV\"\r\n\t  units: 61\r\n\t  stakeholder: customer\r\n    - name: \"bedrijven van 110 kV\"\r\n\t  units: 3\r\n\t  stakeholder: customer "
+      }
+    }
+
+    it 'creates a topology' do
+      perform_post
+
+      expect(Topology.count).to eq(1)
+    end
+  end
+
   describe "creating a topology with stakeholders" do
     let!(:sign_in_user){ sign_in(:user, user) }
     let(:perform_post){


### PR DESCRIPTION
Alliander sometimes uses hard-tabs to indent topology rules. However YAML is not doing so well in interpreting tabs. This code replaces all graph input by 4 spaces.