### PR TITLE
Replacing load profile keys with id's

### DIFF
--- a/app/helpers/testing_grounds_helper.rb
+++ b/app/helpers/testing_grounds_helper.rb
@@ -28,7 +28,7 @@ module TestingGroundsHelper
 
   def profile_table_options_for_profile(technology)
     load_profiles = technology.load_profiles.map do |load_profile|
-      load_profile.key
+      [load_profile.key, load_profile.id]
     end
 
     options_for_select(load_profiles)
@@ -36,7 +36,7 @@ module TestingGroundsHelper
 
   def profile_table_options_for_households(household)
     load_profiles = household.load_profiles.map do |profile|
-      [profile.key, profile.key, data: { edsn: profile.is_edsn? }]
+      [profile.key, profile.id, data: { edsn: profile.is_edsn? }]
     end
 
     options_for_select(load_profiles)
@@ -44,7 +44,7 @@ module TestingGroundsHelper
 
   def options_for_load_profiles
     load_profiles = LoadProfile.all.map do |load_profile|
-      load_profile.key
+      [load_profile.key, load_profile.id]
     end
 
     options_for_select(load_profiles)

--- a/app/models/installed_technology.rb
+++ b/app/models/installed_technology.rb
@@ -125,6 +125,6 @@ class InstalledTechnology
   end
 
   def profile_components
-    @profile_components ||= LoadProfile.by_key(profile).load_profile_components
+    @profile_components ||= LoadProfile.find_by_id(profile).load_profile_components
   end
 end # end

--- a/app/models/installed_technology.rb
+++ b/app/models/installed_technology.rb
@@ -4,7 +4,7 @@ class InstalledTechnology
   attribute :name,     String
   attribute :type,     String, default: 'generic'
   attribute :behavior, String
-  attribute :profile,  String
+  attribute :profile,  Integer
   attribute :load,     Float
   attribute :capacity, Float
   attribute :demand,   Float

--- a/app/services/technology_profiles/query.rb
+++ b/app/services/technology_profiles/query.rb
@@ -6,7 +6,7 @@ module TechnologyProfiles
 
     def query
       Hash[permits.group_by(&:technology).map do |tech_key, techs|
-        [tech_key, techs.map { |tech| tech.load_profile.key }]
+        [tech_key, techs.map { |tech| tech.load_profile_id }]
       end]
     end
 

--- a/db/migrate/20150810145211_rename_used_flex_profiles_in_testing_grounds.rb
+++ b/db/migrate/20150810145211_rename_used_flex_profiles_in_testing_grounds.rb
@@ -1,0 +1,13 @@
+class RenameUsedFlexProfilesInTestingGrounds < ActiveRecord::Migration
+  def change
+    TestingGround.all.each do |testing_ground|
+      testing_ground.technology_profile.each_tech do |tech|
+        if tech.profile.present? && load_profile = LoadProfile.where(key: tech.profile).first
+          tech.profile = load_profile.id
+        end
+      end
+
+      testing_ground.save
+    end
+  end
+end

--- a/db/migrate/20150811075446_remove_obsolete_technology_profiles.rb
+++ b/db/migrate/20150811075446_remove_obsolete_technology_profiles.rb
@@ -1,0 +1,7 @@
+class RemoveObsoleteTechnologyProfiles < ActiveRecord::Migration
+  def change
+    TechnologyProfile.all.map do |tp|
+      tp.delete unless LoadProfile.find_by_id(tp.load_profile_id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150806145209) do
+ActiveRecord::Schema.define(version: 20150811075446) do
+
+  create_table "business_cases", force: true do |t|
+    t.integer  "testing_ground_id"
+    t.text     "financials"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "importable_attributes", force: true do |t|
     t.integer "technology_id"

--- a/spec/controllers/testing_grounds_load_management_controller_spec.rb
+++ b/spec/controllers/testing_grounds_load_management_controller_spec.rb
@@ -21,22 +21,23 @@ RSpec.describe TestingGroundsController do
   # Testing of the buffering of local PV excess in heat pumps
   #
   describe "testing of buffering of local pv excess in heat pumps" do
+    let(:solar_load_profile){ FactoryGirl.create(:load_profile, key: 'solar_pv_test') }
+    let(:heat_pump_load_profile){
+      FactoryGirl.create(:load_profile, key: 'heat_pump_test')
+    }
+
     let!(:load_profiles){
       curves = [
         Network::Curve.new([-1.5, -1.5, -1.5, -1.5, 0,    0]),
         Network::Curve.new([   0,    0,    0,    0, 10.0, 0])
-        #Network::Curve.new([-0.1, -0.1, -1.0, -1.5, -1.5, -1.5, -1.0, -0.1, -0.1, -0.1]),
-        #Network::Curve.new([0, 0, 0, 10.0, 10.0, 10.0, 10.0, 10.0, 0, 0])
       ]
 
       allow_any_instance_of(Calculation::TechnologyLoad).to receive(:profile_for)
         .and_return(*curves)
 
-      solar_load_profile = FactoryGirl.create(:load_profile, key: 'solar_pv_test')
       FactoryGirl.create(:load_profile_component,
                          curve_type: 'default', load_profile: solar_load_profile)
 
-      heat_pump_load_profile = FactoryGirl.create(:load_profile, key: 'heat_pump_test')
       FactoryGirl.create(:load_profile_component,
                          curve_type: 'default', load_profile: heat_pump_load_profile)
 
@@ -48,7 +49,7 @@ RSpec.describe TestingGroundsController do
           "name"        => "Solar PV",
           "type"        => "households_solar_pv_solar_radiation",
           "behavior"    => nil,
-          "profile"     => "solar_pv_test",
+          "profile"     => solar_load_profile.id,
           "load"        => nil,
           "capacity"    => -1.5,
           "demand"      => nil,
@@ -60,7 +61,7 @@ RSpec.describe TestingGroundsController do
           "name"        => "Heat pump",
           "type"        => "households_space_heater_heatpump_air_water_electricity",
           "behavior"    => nil,
-          "profile"     => "heat_pump_test",
+          "profile"     => heat_pump_load_profile.id,
           "load"        => nil,
           "capacity"    => 3.0,
           "demand"      => nil,
@@ -95,8 +96,10 @@ RSpec.describe TestingGroundsController do
   # Testing of the postponing of base load
   #
   describe "applying postponing of base load" do
+    let(:load_profile){
+      FactoryGirl.create(:load_profile, key: 'edsn_inflex_and_flex_parts')
+    }
     let!(:load_profiles){
-      load_profile = FactoryGirl.create(:load_profile, key: 'edsn_inflex_and_flex_parts')
       FactoryGirl.create(:load_profile_component, curve_type: 'flex', load_profile: load_profile)
       FactoryGirl.create(:load_profile_component, curve_type: 'inflex', load_profile: load_profile)
 
@@ -113,7 +116,7 @@ RSpec.describe TestingGroundsController do
           "name"        => "Buildings",
           "type"        => "base_load",
           "behavior"    => nil,
-          "profile"     => "edsn_inflex_and_flex_parts",
+          "profile"     => load_profile.id,
           "load"        => nil,
           "capacity"    => nil,
           "demand"      => 2,
@@ -199,8 +202,10 @@ RSpec.describe TestingGroundsController do
   # - Using one congested node in the topology
   #
   describe "applying saving of base load strategy" do
+    let(:load_profile){
+      FactoryGirl.create(:load_profile, key: 'edsn_inflex_and_flex_parts')
+    }
     let!(:load_profiles){
-      load_profile = FactoryGirl.create(:load_profile, key: 'edsn_inflex_and_flex_parts')
       FactoryGirl.create(:load_profile_component, curve_type: 'flex', load_profile: load_profile)
       FactoryGirl.create(:load_profile_component, curve_type: 'inflex', load_profile: load_profile)
 
@@ -217,7 +222,7 @@ RSpec.describe TestingGroundsController do
           "name"        => "Buildings",
           "type"        => "base_load_buildings",
           "behavior"    => nil,
-          "profile"     => "edsn_inflex_and_flex_parts",
+          "profile"     => load_profile.id,
           "load"        => nil,
           "capacity"    => nil,
           "demand"      => 2,

--- a/spec/models/calculation/context_spec.rb
+++ b/spec/models/calculation/context_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Calculation::Context do
 
     before do
       tg.technology_profile = { 'lv1' => [{
-        'name' => 'Tech One', 'profile' => profile.key
+        'name' => 'Tech One', 'profile' => profile.id
       }]}
     end
 

--- a/spec/models/installed_technology_spec.rb
+++ b/spec/models/installed_technology_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe InstalledTechnology do
 
         context 'and a LoadProfile-based curve' do
           before do
-            expect(LoadProfile).to receive(:by_key).and_return(load_profile)
+            expect(LoadProfile).to receive(:find_by_id).and_return(load_profile)
           end
 
           it 'scales without units' do
@@ -141,7 +141,7 @@ RSpec.describe InstalledTechnology do
 
       context 'and a LoadProfile-based curve' do
         before do
-          expect(LoadProfile).to receive(:by_key).and_return(load_profile)
+          expect(LoadProfile).to receive(:find_by_id).and_return(load_profile)
         end
 
         let(:curve) { tech.profile_curve['flex'] }
@@ -178,7 +178,7 @@ RSpec.describe InstalledTechnology do
 
       context 'and a LoadProfile-based curve' do
         before do
-          expect(LoadProfile).to receive(:by_key).and_return(load_profile)
+          expect(LoadProfile).to receive(:find_by_id).and_return(load_profile)
         end
 
         it 'scales without units' do
@@ -196,7 +196,7 @@ RSpec.describe InstalledTechnology do
       let(:tech) { InstalledTechnology.new(volume: 100.0) }
 
       before do
-        expect(LoadProfile).to receive(:by_key).and_return(load_profile)
+        expect(LoadProfile).to receive(:find_by_id).and_return(load_profile)
       end
 
       it 'scales without units' do
@@ -213,7 +213,7 @@ RSpec.describe InstalledTechnology do
       let(:tech) { InstalledTechnology.new(volume: 100.0, capacity: 0.2) }
 
       before do
-        expect(LoadProfile).to receive(:by_key).and_return(load_profile)
+        expect(LoadProfile).to receive(:find_by_id).and_return(load_profile)
       end
 
       it 'scales without units' do

--- a/spec/services/testing_ground/technology_profile_scheme_spec.rb
+++ b/spec/services/testing_ground/technology_profile_scheme_spec.rb
@@ -71,7 +71,9 @@ RSpec.describe TestingGround::TechnologyProfileScheme do
       }
 
       it 'expects only EDSN profiles' do
-        expect(new_profile.values.flatten.first["profile"]).to eq("anonimous_1")
+        load_profile_id = new_profile.values.flatten.first["profile"]
+
+        expect(LoadProfile.find(load_profile_id).key).to eq("anonimous_1")
       end
     end
 
@@ -83,7 +85,9 @@ RSpec.describe TestingGround::TechnologyProfileScheme do
       }
 
       it 'only makes use of non-EDSN profiles' do
-        expect(new_profile.values.flatten.first["profile"]).to eq("anonimous_1")
+        load_profile_id = new_profile.values.flatten.first["profile"]
+
+        expect(LoadProfile.find(load_profile_id).key).to eq("anonimous_1")
       end
     end
   end


### PR DESCRIPTION
- Saves space in the database
- Makes renaming of the keys easier without breaking the whole database

Fixes #261 