### PR TITLE
Upgrade Airbrake

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -50,5 +50,6 @@ namespace :deploy do
   end
 
   after 'deploy:compile_assets', 'paperclip:build_missing_styles'
+  after 'deploy:finished', 'airbrake:deploy'
   after :publishing, :restart
 end


### PR DESCRIPTION
I would like to have deployment integration.

This script should generate the `config/initializer/airbrake.rb` file according to the [manual](https://github.com/airbrake/airbrake): 

```
bundle exec rails generate airbrake --api-key THE_ETMOSES_AIRBRAKE_KEY
```

But it complains here:

```
Don't know how to build task 'airbrake:test'
```