### PR TITLE
Store EditableTable events in the instance

### DIFF
--- a/app/assets/javascripts/tables/editable_table.js
+++ b/app/assets/javascripts/tables/editable_table.js
@@ -1,12 +1,10 @@
 var EditableTable = (function(){
-  var selector, changeData, changeListener;
-
   EditableTable.prototype = {
     append: function(_changeListener, _changeData){
-      changeListener = (_changeListener || function(){});
-      changeData = (_changeData || function(){});
+      this.changeListener = (_changeListener || function(){});
+      this.changeData = (_changeData || function(){});
 
-      $(this.selector).on('change', changeListener.bind(this));
+      $(this.selector).on('change', this.changeListener.bind(this));
 
       addClickListenersToAddRow.call(this);
       addClickListenersToDeleteRow.call(this);
@@ -30,8 +28,13 @@ var EditableTable = (function(){
     $.each(tableRow, function(i, attribute){
       var header = tableHeader.call(self, i);
       tableData[header] = attribute;
-      changeData.call({ attribute: attribute, header: header, tableData: tableData });
-    });
+
+      this.changeData.call({
+        attribute: attribute,
+        header: header,
+        tableData: tableData
+      });
+    }.bind(this));
     return tableData;
   };
 
@@ -58,24 +61,27 @@ var EditableTable = (function(){
     $(this.selector).find("a.add-row").on("click", function(e){
       e.preventDefault();
 
-      var row = $(this).parents("tr");
+      var row = $(e.currentTarget).parents("tr");
       var clonedRow = row.clone(true, true);
       clonedRow.insertAfter(row);
-      changeListener.call();
-    });
+      this.changeListener();
+    }.bind(this));
   };
 
   function addClickListenersToDeleteRow(){
     $(this.selector).find("a.remove-row").on("click", function(e){
       e.preventDefault();
 
-      $(this).parents("tr").remove();
-      changeListener.call();
-    });
+      $(e.currentTarget).parents("tr").remove();
+      this.changeListener();
+    }.bind(this));
   };
 
   function EditableTable(_selector){
     this.selector = _selector;
+
+    this.changeListener = function() {};
+    this.changeData = function() {};
   };
 
   return EditableTable;


### PR DESCRIPTION
Moved `changeListener` and `changeData` callbacks to be stored within the EditableTable instance, instead of being global within the anonymous closure. The old global variables would have their values overwritten each time a new EditableTable was created.

**Why this is needed?**

Previously, if muliple EditableTable instances were created (on the LES edit page) the callback event from the most-recently created table would replace the event on the older ones. In particular, it meant we couldn't add or remove rows to the market model table because the callback event from the *technology profile table* was being run instead. The correct callback would be run, apparently, only if you edit a value in the market model table prior to submitting the form.

**Steps to reproduce**

1. Visit the "Edit LES" page
2. Click the "Market model" tab
3. Remove a row
4. Without focusing any of the form fields in the table, press "Save"
5. Refresh the page, and note that the deleted row has reappeared.

@grdw Could you review this and let me know what you think? I'm not sure what the reason was for the global `changeListener` and `changeData` variables, but as this isn't a technique I've seen before for creating JS classes, I don't want to make this change to `master` without you reviewing it first.