### PR TITLE
Removes all NaN's for conditional consumption

### DIFF
--- a/app/models/network/path.rb
+++ b/app/models/network/path.rb
@@ -55,7 +55,7 @@ module Network
     #
     # Returns a numeric.
     def available_capacity_at(frame)
-      @path.map { |node| node.available_capacity_at(frame) }.min
+      @path.map { |node| node.available_capacity_at(frame) }.reject(&:nan?).min
     end
 
     # Public: Determines if the load of the any node in the path node exceeds


### PR DESCRIPTION
@antw  please have a look because this looks rather patchy. 

It's for the error generated here: http://beta.moses.et-model.com/testing_grounds/143

It does fix the problem but I must say that I have no clue how it get's those `NaN`'s in the first place. Maybe you know a better solution than this patch fix?