### PR TITLE
Fixes #684

### DIFF
--- a/app/assets/javascripts/les/profile_select_box.js
+++ b/app/assets/javascripts/les/profile_select_box.js
@@ -68,20 +68,23 @@ var ProfileSelectBox = (function () {
     }
 
     function addChangeListenerToProfileBox() {
-        var currentSelect = $(this.target).find(".editable.profile select");
+        var self = this;
 
-        $(".editable.profile select").add(currentSelect).off().on("change", function () {
+        $(this.target).find(".editable.profile select").off().on("change", function () {
             var technology = $(this).parents(".technology");
 
             technology.set('profile', $(this).val());
             technology.set('profile-key', $(this).selectedOption().text());
 
             updateTextCells.call(technology, this);
+            self.callback.call(this);
         });
     }
 
     ProfileSelectBox.prototype = {
-        add: function () {
+        add: function (callback) {
+            this.callback = (callback || function () { return; });
+
             cloneAndAppendProfileSelect.call(this);
             addChangeListenerToProfileBox.call(this);
         },

--- a/app/assets/javascripts/les/technologies_form.js
+++ b/app/assets/javascripts/les/technologies_form.js
@@ -137,7 +137,8 @@ var TechnologiesForm = (function () {
     TechnologiesForm.prototype = {
         append: function () {
             $(".technologies .technology:not(.hidden)").each(function () {
-                new Technology(this).update();
+                new ProfileSelectBox(this).add(updateJSON);
+                new BufferSelectBox(this).add();
 
                 addOnChangeListener.call(this);
             });

--- a/app/assets/javascripts/les/technology.js
+++ b/app/assets/javascripts/les/technology.js
@@ -10,11 +10,6 @@ var Technology = (function () {
             new BufferSelectBox(this.technologyDom).add();
 
             $(target).after(this.technologyDom);
-        },
-
-        update: function () {
-            new ProfileSelectBox(this.technologyDom).add();
-            new BufferSelectBox(this.technologyDom).add();
         }
     };
 

--- a/app/helpers/testing_grounds_helper.rb
+++ b/app/helpers/testing_grounds_helper.rb
@@ -115,6 +115,7 @@ module TestingGroundsHelper
   def technology_class(technology)
     technology_class = technology.type
     technology_class += " buffer-child" if technology.buffer.present?
+    technology_class += " alert-danger" unless technology.valid?
     technology_class
   end
 end

--- a/app/models/calculation/context.rb
+++ b/app/models/calculation/context.rb
@@ -57,7 +57,7 @@ module Calculation
         end
 
         techs.map do |tech|
-          tech.profile.present? ? tech.profile_curve.first.last.length : 1
+          tech.valid_profile? ? tech.profile_curve.first.last.length : 1
         end.max || 1
       end
     end

--- a/app/models/installed_technology.rb
+++ b/app/models/installed_technology.rb
@@ -249,6 +249,18 @@ class InstalledTechnology
     "position_relative_to_buffer_#{@id}_#{type}"
   end
 
+  def valid?
+    buffer.present? || valid_profile?
+  end
+
+  def valid_profile?
+    if profile.is_a?(Hash)
+      profile.present?
+    else
+      profile.present? && load_profile.present?
+    end
+  end
+
   private
 
   def has_heat_pump_profiles?
@@ -260,7 +272,9 @@ class InstalledTechnology
   #
   # Returns a Hash[{ <curve_type> => Network::Curve }].
   def profile_curves(scaling = nil)
-    Hash[profile_components.each_curve(scaling).map do |curve_type, curve, ratio|
+    return {} unless valid_profile?
+
+    Hash[load_profile.curves.each_curve(scaling).map do |curve_type, curve, ratio|
       [curve_type, curve * component_factor(curve) * ratio]
     end]
   end
@@ -276,7 +290,7 @@ class InstalledTechnology
     (factor / performance_coefficient) * units
   end
 
-  def profile_components
-    @profile_components ||= LoadProfile.find_by_id(profile).curves
+  def load_profile
+    @load_profile ||= LoadProfile.find_by_id(profile)
   end
 end # end

--- a/app/models/testing_ground.rb
+++ b/app/models/testing_ground.rb
@@ -125,6 +125,10 @@ class TestingGround < ActiveRecord::Base
     self.technology_profile = TechnologyList.from_csv(csv)
   end
 
+  def invalid_technologies
+    technology_profile.list.values.flatten.reject(&:valid?)
+  end
+
   private
 
   # Asserts that the technologies used in the graph have all been defined in

--- a/app/services/testing_ground/calculator.rb
+++ b/app/services/testing_ground/calculator.rb
@@ -57,7 +57,19 @@ class TestingGround::Calculator
     SelectedStrategy.strategy_type(@strategies)
   end
 
+  def invalid_message
+    invalid_technologies = @testing_ground.invalid_technologies.map do |tech|
+      "'#{tech.name}' on '#{tech.node}'"
+    end
+
+    if invalid_technologies.any?
+      I18n.t("testing_grounds.error.invalid_technologies",
+          invalid_technologies: invalid_technologies.join(", "))
+    end
+  end
+
   def base
-    { technologies: @testing_ground.technology_profile.as_json }
+    { technologies: @testing_ground.technology_profile.as_json,
+      error: invalid_message }
   end
 end

--- a/app/services/testing_ground/technology_partitioner.rb
+++ b/app/services/testing_ground/technology_partitioner.rb
@@ -25,8 +25,9 @@ class TestingGround::TechnologyPartitioner
     technology
   end
 
+  # TODO: This should be cleaned
   def couple_composite(technology, index)
-    technology.composite_index = ((technology.composite_index || 1) - 1) * @size + (index + 1)
+    technology.composite_index = ((technology.composite_index || 1).to_i - 1) * @size + (index + 1)
 
     if technology.composite
       technology.name = technology.get_composite_name

--- a/app/views/testing_grounds/show.html.haml
+++ b/app/views/testing_grounds/show.html.haml
@@ -1,3 +1,8 @@
+.alert.alert-warning.hidden{role: 'alert'}
+  %span.glyphicon.glyphicon-exclamation-sign{"aria-hidden" => "true"}
+  %span.sr-only Warning:
+  %span.error
+
 .header
   %h1
     %span.name= @testing_ground.name
@@ -87,7 +92,7 @@
                       %th Units
                   %tbody
                     - techs.each do |tech|
-                      %tr{ "data-tech" => tech.name }
+                      %tr{ class: ("danger" unless tech.valid?), "data-tech" => tech.name}
                         %td
                           .name= tech.name
                           %i.profile= tech.profile_key

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
       profile_not_found: >
         You are using a non-existent profile called '%{profile}',
         please check your technologies.
+      invalid_technologies: "The profiles used by: %{invalid_technologies} no longer exist. Please assign a new profile"
 
     form:
       public:
@@ -68,7 +69,7 @@ en:
 
       position_relative_to_buffer:
         tooltip: >
-          'Buffering' technologies fill the buffer until full. 'Boosting' technologies 
+          'Buffering' technologies fill the buffer until full. 'Boosting' technologies
           satisfy demand if the buffer is empty or has insufficient capacity.
 
     strategies:

--- a/spec/models/testing_ground/load_management_spec.rb
+++ b/spec/models/testing_ground/load_management_spec.rb
@@ -51,8 +51,6 @@ RSpec.describe TestingGround do
           "composite_value" => "buffer_space_heating_1",
           "behavior"        => nil,
           "profile"         => heat_pump_load_profile,
-          # "capacity" => null,
-          # "demand" => 70080.0,
           "volume"          => 0.5,
           "units"           => 1,
           "concurrency"     => "max"


### PR DESCRIPTION
In this pull request there's code that allows a network calculation to continue eventhough a profile is not found. There will be a message in the header of those LES's with technologies without a profile which will say that there's something wrong with their current LES and where (on which node and which technology) the problem lies.