### PR TITLE
Issues/#750 solar pv capacity incorrect

### DIFF
--- a/app/assets/javascripts/les/template_settings.js
+++ b/app/assets/javascripts/les/template_settings.js
@@ -27,7 +27,8 @@ var TemplateSettings = (function () {
         ],
         etmKeys: [
             'technicalLifetime', 'initialInvestment', 'fullLoadHours',
-            'omCostsPerYear', 'omCostsPerFullLoadHour', 'omCostsForCcsPerFullLoadHour'
+            'omCostsPerYear', 'omCostsPerFullLoadHour', 'omCostsForCcsPerFullLoadHour',
+            'capacity', 'volume', 'demand'
         ]
     };
 }());


### PR DESCRIPTION
Before merging this there needs to be a check if the 

`demand`, `volume` and `capacity` of the following technologies are correct:

| Ok? | Technology                                                            | Demand  | Volume  | Capacity     |
| ------ | ---------------------------------------------------------------- | ------------ | ----------- | --------------- |
|         | energy_flexibility_p2g_electricity                          |                |                | 739.583333333333 |
|         | households_flexibility_p2h_electricity                   |                | 7.2         |  2 |
|         | households_flexibility_p2p_electricity                   |               | 9.6         | 5.176470588235294 |
| x      | households_solar_pv_solar_radiation                  |               |                |  -1.6 |
|         | households_space_heater_combined_network_gas |         |                | 20.61855670103093 |
|         | households_space_heater_heatpump_air_water_electricity | |            |  10   |
|         | households_space_heater_heatpump_ground_water_electricity  ||    | 10 |
|         | households_space_heater_network_gas                             ||| 27.499999999999996 |
|         | households_water_heater_combined_network_gas                    ||||
|         | households_water_heater_heatpump_air_water_electricity          ||| 10 |
|         | households_water_heater_heatpump_ground_water_electricity       ||| 10 |
|         | households_water_heater_network_gas                             ||||
| x       | transport_car_using_electricity                                 || 20 | 3.7 |

Hidden:

| Ok? | Technology                                                            | Demand  | Volume  | Capacity     |
| ------ | ---------------------------------------------------------------- | ------------ | ----------- | --------------- |
|         | households_water_heater_micro_chp_network_gas                   ||||
|         | households_water_heater_fuel_cell_chp_network_gas               ||||
|         | households_space_heater_micro_chp_network_gas                   ||| |

I left out the hybrid heat pumps because their values are not questioned in et-engine from the front-end but set in separate parts. Those parts don't relate to anyting in et-engine and therefor only have the preset defaults from the database.

Including @ChaelKruip 
