### PR TITLE
Set profile once <select> has been initialized

### DIFF
--- a/app/assets/javascripts/les/profile_matrix_editor/edsn_switch.js
+++ b/app/assets/javascripts/les/profile_matrix_editor/edsn_switch.js
@@ -22,6 +22,7 @@ var EdsnSwitch = (function () {
             select.trigger('change');
         }
 
+        $(this.target).set('profile', parseInt(select.val(), 10));
         $(this.target).set('type', actual);
 
         unitSelector.off('change.units').on('change.units', swapSelectBox.bind(self));


### PR DESCRIPTION
I hate to say it, but I tried importing the same 300 household scenario again and, despite the import form showing "edsn_e1a", the base load got saved with "anonimous_base_load_1".

A previous version of the pull request #773 (2ba2ed5) did work, so I resurrected one of the lines which was removed from the merged version.

@grdw Does this look right to you?