### PR TITLE
Issues/#794 distinguish between selectable profiles

### DIFF
--- a/app/controllers/load_profiles_controller.rb
+++ b/app/controllers/load_profiles_controller.rb
@@ -63,7 +63,7 @@ class LoadProfilesController < ResourceController
   def profile_params
     params.require(:load_profile).permit(
       :key, :name, :public, :load_profile_category_id, :default_capacity,
-      :default_demand, :default_volume,
+      :default_demand, :default_volume, :included_in_concurrency,
       { technology_profiles_attributes: [:id, :technology, :_destroy] },
       { load_profile_components_attributes: [:id, :curve, :curve_type]}
     )

--- a/app/controllers/load_profiles_controller.rb
+++ b/app/controllers/load_profiles_controller.rb
@@ -61,11 +61,6 @@ class LoadProfilesController < ResourceController
   end
 
   def profile_params
-    params.require(:load_profile).permit(
-      :key, :name, :public, :load_profile_category_id, :default_capacity,
-      :default_demand, :default_volume, :included_in_concurrency,
-      { technology_profiles_attributes: [:id, :technology, :_destroy] },
-      { load_profile_components_attributes: [:id, :curve, :curve_type]}
-    )
+    permitted_attributes(@profile || LoadProfile.new)
   end
 end

--- a/app/policies/load_profile_policy.rb
+++ b/app/policies/load_profile_policy.rb
@@ -1,3 +1,7 @@
 class LoadProfilePolicy < ApplicationPolicy
   include PrivatePolicy
+
+  def modify_concurrency?
+    user.admin?
+  end
 end

--- a/app/policies/load_profile_policy.rb
+++ b/app/policies/load_profile_policy.rb
@@ -1,7 +1,22 @@
 class LoadProfilePolicy < ApplicationPolicy
   include PrivatePolicy
 
+  PERMITTED_ATTRIBUTES = [
+    :key, :name, :public, :load_profile_category_id,
+    :default_capacity, :default_demand, :default_volume,
+    { technology_profiles_attributes: [:id, :technology, :_destroy] },
+    { load_profile_components_attributes: [:id, :curve, :curve_type]}
+  ].freeze
+
   def modify_concurrency?
     user.admin?
+  end
+
+  def permitted_attributes
+    if modify_concurrency?
+      PERMITTED_ATTRIBUTES.dup.push(:included_in_concurrency)
+    else
+      PERMITTED_ATTRIBUTES
+    end
   end
 end

--- a/app/services/load_profiles/selector.rb
+++ b/app/services/load_profiles/selector.rb
@@ -8,8 +8,8 @@ module LoadProfiles
     # Public: Creates a ProfileSelector which selects profiles for the given
     # +technologies+ keys.
     def initialize(profiles, technology)
+      @profiles   = profiles[technology.type]
       @technology = technology
-      @profiles   = selected_profiles(profiles)
     end
 
     def select_profile
@@ -45,10 +45,6 @@ module LoadProfiles
 
     def minimize_concurrency?
       @technology.concurrency == 'min' && !is_edsn?
-    end
-
-    def selected_profiles(profiles)
-      profiles[@technology.type]
     end
   end
 end

--- a/app/services/technology_profiles/query.rb
+++ b/app/services/technology_profiles/query.rb
@@ -6,7 +6,8 @@ module TechnologyProfiles
 
     def query
       Hash[permits.group_by(&:technology).map do |tech_key, techs|
-        [tech_key, techs.map { |tech| tech.load_profile_id }]
+        [ tech_key, techs.select(&method(:included_in_concurrency?))
+                         .map(&:load_profile_id) ]
       end]
     end
 
@@ -16,8 +17,13 @@ module TechnologyProfiles
       @distribution.map{|t| t['type']}.uniq
     end
 
+    def included_in_concurrency?(tech)
+      tech.load_profile.included_in_concurrency?
+    end
+
     def permits
-      TechnologyProfile.where(technology: technology_keys).includes(:load_profile)
+      TechnologyProfile.where(technology: technology_keys)
+        .includes(:load_profile)
     end
   end
 end

--- a/app/views/load_profiles/_form.html.haml
+++ b/app/views/load_profiles/_form.html.haml
@@ -40,6 +40,12 @@
       = form.radio_button :public, false
       = form.label :public, "Private", class: "radio-label"
 
+  - if current_user.admin?
+    .form-group
+      %label
+        = form.check_box :included_in_concurrency
+        Included in concurrency
+
   .form-group
     = form.label :load_profile_category_id
     = form.select :load_profile_category_id, load_profile_categories_select_options(@profile), {}, class: 'form-control'

--- a/app/views/load_profiles/_form.html.haml
+++ b/app/views/load_profiles/_form.html.haml
@@ -40,7 +40,7 @@
       = form.radio_button :public, false
       = form.label :public, "Private", class: "radio-label"
 
-  - if current_user.admin?
+  - if policy(:load_profile).modify_concurrency?
     .form-group
       %label
         = form.check_box :included_in_concurrency

--- a/db/migrate/20160217110749_add_can_concur_to_load_profiles.rb
+++ b/db/migrate/20160217110749_add_can_concur_to_load_profiles.rb
@@ -1,0 +1,5 @@
+class AddCanConcurToLoadProfiles < ActiveRecord::Migration
+  def change
+    add_column :load_profiles, :included_in_concurrency, :boolean, default: false
+  end
+end

--- a/db/migrate/20160217130917_update_included_in_concurrency_for_all_load_profiles.rb
+++ b/db/migrate/20160217130917_update_included_in_concurrency_for_all_load_profiles.rb
@@ -1,0 +1,5 @@
+class UpdateIncludedInConcurrencyForAllLoadProfiles < ActiveRecord::Migration
+  def change
+    LoadProfile.update_all(included_in_concurrency: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160217110749) do
+ActiveRecord::Schema.define(version: 20160217130917) do
 
   create_table "business_cases", force: true do |t|
     t.integer  "testing_ground_id"
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 20160217110749) do
     t.float    "default_demand",           limit: 24
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "can_concur",                          default: false
+    t.boolean  "included_in_concurrency",             default: false
   end
 
   add_index "load_profiles", ["key"], name: "index_load_profiles_on_key", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160215144730) do
+ActiveRecord::Schema.define(version: 20160217110749) do
 
   create_table "business_cases", force: true do |t|
     t.integer  "testing_ground_id"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20160215144730) do
     t.float    "default_demand",           limit: 24
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "can_concur",                          default: false
   end
 
   add_index "load_profiles", ["key"], name: "index_load_profiles_on_key", unique: true, using: :btree

--- a/spec/factories/load_profiles.rb
+++ b/spec/factories/load_profiles.rb
@@ -3,10 +3,12 @@ include ActionDispatch::TestProcess
 FactoryGirl.define do
   factory :load_profile do
     sequence(:key){|n| "key_#{n}"}
+    included_in_concurrency true
   end
 
   factory :load_profile_with_curve, class: LoadProfile do
     sequence(:key) {|n| "key_#{n}_with_curve"}
+    included_in_concurrency true
 
     load_profile_components { build_list :load_profile_component, 1 }
   end

--- a/spec/services/technology_profiles/query_spec.rb
+++ b/spec/services/technology_profiles/query_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe TechnologyProfiles::Query do
+  let!(:technology_profile) {
+    FactoryGirl.create(:technology_profile,
+                        technology: "households_solar_pv_solar_radiation",
+                        load_profile: load_profile)
+  }
+
+  let(:query) {
+    TechnologyProfiles::Query.new(
+      [{'type' => 'households_solar_pv_solar_radiation'}]).query
+  }
+
+  describe "with allowed technology profiles for concurrency" do
+    let(:load_profile){ FactoryGirl.create(:load_profile,
+      included_in_concurrency: false
+    ) }
+
+    it "queries the technology profiles of a solar pv" do
+      expect(query).to eq({"households_solar_pv_solar_radiation"=>[]})
+    end
+  end
+
+  describe "with non-allowed technology profiles for concurrency" do
+    let(:load_profile){
+      FactoryGirl.create(:load_profile)
+    }
+
+    it "queries the technology profiles of a solar pv" do
+      expect(query).to eq({
+        "households_solar_pv_solar_radiation"=>[load_profile.id]
+      })
+    end
+  end
+end


### PR DESCRIPTION
Please merge https://github.com/quintel/etmoses/pull/782 first - before merging this.

---

This PR closes: #794 

Adds a boolean to `load_profiles` that includes/excluded load profiles from the concurrency method.