### PR TITLE
Force SSL on staging and production environments

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,6 +12,7 @@ Rails.application.configure do
   config.active_support.deprecation                = :notify
   config.log_formatter                             = ::Logger::Formatter.new
   config.active_record.dump_schema_after_migration = false
+  config.force_ssl                                 = true
 
   # Temporarily use in-memory caching.
   config.cache_store = :memory_store, { size: 64.megabytes }


### PR DESCRIPTION
Assuming production will get an SSL certificate as well.

Also because the staging.rb now points to the production rb. 

Fixes: #816 