### PR TITLE
Check if the actual accompanied delayed job is present when recalculating a LES

### DIFF
--- a/app/assets/javascripts/les/topology_load_charts/d3_load_chart.js
+++ b/app/assets/javascripts/les/topology_load_charts/d3_load_chart.js
@@ -520,7 +520,6 @@ var D3LoadChart = (function () {
                 .attr("transform", "translate(0," + height + ")")
                 .call(xAxis);
 
-            console.log(data.type);
             svg.append("g")
                 .attr("class", "y axis")
                 .call(yAxis)

--- a/app/jobs/testing_ground_calculator_job.rb
+++ b/app/jobs/testing_ground_calculator_job.rb
@@ -12,7 +12,7 @@ class TestingGroundCalculatorJob
     if job = @testing_ground.testing_ground_delayed_jobs.for(job_type)
       TestingGround::StrategyUpdater.new(@testing_ground, strategy_params).update
 
-      job.update_column(:finished_at, DateTime.now)
+      job.destroy
     end
   end
 

--- a/app/services/testing_ground/calculator.rb
+++ b/app/services/testing_ground/calculator.rb
@@ -34,7 +34,7 @@ class TestingGround::Calculator
   end
 
   def calculate_load_in_background
-    return if existing_job
+    return if existing_job && existing_job.job
 
     job = @testing_ground.testing_ground_delayed_jobs.create!(job_type: job_type)
     job.update_attribute(:job, Delayed::Job.enqueue(task))

--- a/app/services/testing_ground/calculator.rb
+++ b/app/services/testing_ground/calculator.rb
@@ -8,13 +8,11 @@ class TestingGround::Calculator
 
   def calculate
     if ! Settings.cache.networks || cache.present?
-      existing_job.destroy if existing_job
-
       base.merge(networks: tree)
     else
       calculate_load_in_background
 
-      @strategies.merge(pending: existing_job.finished_at.blank?)
+      @strategies.merge(pending: existing_job.present?)
     end
   end
 

--- a/db/migrate/20160303130158_remove_finished_at_column_from_testing_ground_delayed_jobs.rb
+++ b/db/migrate/20160303130158_remove_finished_at_column_from_testing_ground_delayed_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveFinishedAtColumnFromTestingGroundDelayedJobs < ActiveRecord::Migration
+  def change
+    remove_column :testing_ground_delayed_jobs, :finished_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229174038) do
+ActiveRecord::Schema.define(version: 20160303130158) do
 
   create_table "business_cases", force: true do |t|
     t.integer  "testing_ground_id"
@@ -141,7 +141,9 @@ ActiveRecord::Schema.define(version: 20160229174038) do
     t.boolean "composite",                                       default: false
     t.float   "default_capacity",                    limit: 24
     t.float   "default_volume",                      limit: 24
+    t.float   "default_volume_in_liters",            limit: 24
     t.float   "default_demand",                      limit: 24
+    t.float   "max_bufferable_temperature",          limit: 24
     t.string  "default_position_relative_to_buffer"
     t.boolean "expandable",                                      default: true
   end
@@ -165,10 +167,9 @@ ActiveRecord::Schema.define(version: 20160229174038) do
   add_index "technology_profiles", ["load_profile_id"], name: "index_technology_profiles_on_load_profile_id", using: :btree
 
   create_table "testing_ground_delayed_jobs", force: true do |t|
-    t.integer  "testing_ground_id"
-    t.integer  "job_id"
-    t.string   "job_type"
-    t.datetime "finished_at"
+    t.integer "testing_ground_id"
+    t.integer "job_id"
+    t.string  "job_type"
   end
 
   create_table "testing_grounds", force: true do |t|

--- a/spec/services/testing_ground/calculator_spec.rb
+++ b/spec/services/testing_ground/calculator_spec.rb
@@ -10,7 +10,14 @@ RSpec.describe TestingGround::Calculator do
   it 'sets a testing ground delayed job' do
     TestingGround::Calculator.new(testing_ground, {}).calculate
 
-    expect(TestingGroundDelayedJob.count).to eq(1)
+    expect(Delayed::Job.count).to eq(1)
+  end
+
+  it "should calculate when the 'testing_ground_delayed_job' is still present but the delayed job isn't" do
+    TestingGroundDelayedJob.create!(testing_ground: testing_ground, job_type: 'basic', job_id: 0)
+    TestingGround::Calculator.new(testing_ground, {}).calculate
+
+    expect(Delayed::Job.count).to eq(1)
   end
 
   context 'with a fresh cache' do


### PR DESCRIPTION
Thing is now that when somebody calculates a LES the first time, the cache is properly written but somebody can still cancel the request (for instance out of a rush, before a demo, moving away from the page) (which results in the `testing_ground_delayed_job` not being destroyed).

The next time somebody makes a change the calculator sees that there already was a previous calculation (`testing_ground_delayed_job`) present and finished, which will cause the server to think that it's done while there's nothing valid in the cache is to show to the front-end (which is the error Alex was seeing).

So my fix would be when recalculating to check if the accompanied `delayed_job` of the `testing_ground_delayed_job` didn't already finish (i.e. if it's still present or not).