### PR TITLE
Fix loads per week issues for electricity load

### DIFF
--- a/app/assets/javascripts/les/topology_load_charts/chart_shower.js
+++ b/app/assets/javascripts/les/topology_load_charts/chart_shower.js
@@ -109,7 +109,7 @@ var ChartShower = (function () {
                 return false;
             }
 
-            window.currentTree.nodes.push(this.nodeData.name);
+            window.currentTree.addNode(this.nodeData.name);
             renderLoadChart.call(this, this.nodeData);
             toggleDomParts.call(this.nodeData);
         }

--- a/app/assets/javascripts/les/topology_load_charts/tree.js
+++ b/app/assets/javascripts/les/topology_load_charts/tree.js
@@ -82,6 +82,12 @@ var Tree = (function () {
             this.loading = !this.loading;
 
             $("button.apply_strategies").prop("disabled", loadingSpinner.hasClass("on"));
+        },
+
+        addNode: function (name) {
+            if (!(this.nodes.indexOf(name) > -1)) {
+                this.nodes.push(name);
+            }
         }
     };
 

--- a/app/models/calculation/technology_load.rb
+++ b/app/models/calculation/technology_load.rb
@@ -68,7 +68,7 @@ module Calculation
           Network::Technologies::Composite::Manager.new(
             (comp.capacity || Float::INFINITY) * comp.units,
             comp.volume * comp.units,
-            comp.profile_curve.curves.fetch('default'.freeze)
+            comp.profile_curve(@context.options[:range]).cut_curves.fetch('default'.freeze)
           )
       end
     end

--- a/app/models/installed_technology/profile_curve.rb
+++ b/app/models/installed_technology/profile_curve.rb
@@ -11,7 +11,7 @@ class InstalledTechnology
 
     def each
       if has_heat_pump_profiles?
-        yield(cut_curves.keys.sort.join('_'), *curves.values)
+        yield(cut_curves.keys.sort.join('_'), *cut_curves.values)
       else
         cut_curves.each_pair.map do |curve_type, curve|
           yield(curve_type, curve)
@@ -23,13 +23,13 @@ class InstalledTechnology
       curves.keys.sort == %w(availability use)
     end
 
-    private
-
     def cut_curves
       Hash[curves.map do |curve_type, curve|
         [curve_type, curve ? slice_curve(curve) : nil]
       end]
     end
+
+    private
 
     def slice_curve(curve)
       curve_range = (range ? range : 0...(curve.size / 52))

--- a/app/services/network_cache/fetcher.rb
+++ b/app/services/network_cache/fetcher.rb
@@ -11,18 +11,20 @@ module NetworkCache
     def fetch(nodes = nil)
       tree_scope.each do |network|
         LoadSetter.set(network, nodes) do |node|
-          caches = FOLDERS.values.map do |frame|
-            read(file_name(network.carrier, node.key, frame))
+          if year = read(network.carrier, node.key, 'year')
+            year[@range ? @range : 0..-1]
+          elsif current_week = read(network.carrier, node.key, 'current_week')
+            current_week
           end
-
-          (caches.detect(&:present?) || [])[@range ? @range : 0..-1]
         end
       end
 
       tree_scope
     end
 
-    def read(file)
+    def read(carrier, key, time_frame)
+      file = file_name(carrier, key, time_frame)
+
       if File.exists?(file)
         MessagePack.unpack(File.read(file))
       end


### PR DESCRIPTION
Fixes: #881 

To reproduce: 
1. turn on caching. 
2. Add some gas technologies. 
3. Change the week 
4. Cry

Unfortunately this doesn't yet work for gas for some yet to be discovered reason... It now just shows the load of week 1 - always for gas. It annoys me but I can't figure where it fetches the loads of week 1 and for gas technologies only. I'll look into it tomorrow.