### PR TITLE
Fix selecting nodes which have no gas load

### DIFF
--- a/app/assets/javascripts/les/topology_load_charts/chart_shower.js
+++ b/app/assets/javascripts/les/topology_load_charts/chart_shower.js
@@ -134,8 +134,8 @@ var ChartShower = (function () {
     function isValidNodeData() {
         var d = this.nodeData;
 
-        return (d.load && d.load.total.length > 0) ||
-               (d.gas && d.gas.total.length > 0);
+        return (d.load && d.load.total && d.load.total.length) ||
+               (d.gas && d.gas.total && d.gas.total.length);
     }
 
     ChartShower.prototype = {


### PR DESCRIPTION
@grdw Could you check that this change makes sense? When caching was enabled, nodes which have no gas would raise an error in `isValidNodeData` because `d.gas.total` would be `undefined`. This change checks that the `total` is set before asserting the array length is non-zero.

I tested locally and the charts for all nodes seem to load correctly.

Ref #947.