### PR TITLE
Destroy network cache before calculating

### DIFF
--- a/app/jobs/testing_ground_calculator_job.rb
+++ b/app/jobs/testing_ground_calculator_job.rb
@@ -6,6 +6,7 @@ class TestingGroundCalculatorJob
   end
 
   def perform
+    cache.destroy
     cache.write(network_calculation)
   end
 

--- a/app/services/network_cache/cache.rb
+++ b/app/services/network_cache/cache.rb
@@ -15,6 +15,10 @@ module NetworkCache
       Fetcher.from(@testing_ground, **@opts).fetch(nodes)
     end
 
+    def destroy
+      Destroyer.from(@testing_ground, **@opts).destroy
+    end
+
     def present?
       Validator.from(@testing_ground, **@opts).valid?
     end


### PR DESCRIPTION
@grdw Could you see if this fixes the gas cache issue for you?

My guess is that the "strategies off" calculation was finishing before "strategies on", and the app thought that the "strategies on" load was also complete. Thus, it would be sending the *old* cached loads even though the "strategies on" calculation was still running.

This change deletes the cache before starting the calculation. That should prevent the old "strategies on" cache from being considered valid.

Closes #1044 