### PR TITLE
Show only whitelisted attributes on technology form

### DIFF
--- a/app/assets/stylesheets/testing_grounds.css.scss
+++ b/app/assets/stylesheets/testing_grounds.css.scss
@@ -442,6 +442,10 @@ table.table.scenarios{
         float: left;
       }
 
+      &.carrier_capacity {
+        clear: left;
+      }
+
       &.buffer select,
       &.profile select{
         width: 550px;

--- a/app/views/testing_grounds/_technology_template.html.haml
+++ b/app/views/testing_grounds/_technology_template.html.haml
@@ -48,15 +48,17 @@
         = tooltip_tag(t(:'testing_grounds.form.congestion_reserve_percentage.tooltip'))
         .clearfix
 
-    .editable.text{class: 'capacity'}
-      %span Output capacity [kW]
-      %input.form-control{type: 'text', value: technology.capacity.try(:round, 4), data: { type: 'capacity' } }
-      .clearfix
+    - if technology.whitelisted?('output_capacity')
+      .editable.text{class: 'capacity'}
+        %span Output capacity [kW]
+        %input.form-control{type: 'text', value: technology.capacity.try(:round, 4), data: { type: 'capacity' } }
+        .clearfix
 
-    .editable.text{class: 'demand'}
-      %span Demand [kWh]
-      %input.form-control{type: 'text', value: technology.demand.try(:round, 2), data: { type: 'demand'} }
-      .clearfix
+    - if technology.whitelisted?('demand')
+      .editable.text{class: 'demand'}
+        %span Demand [kWh]
+        %input.form-control{type: 'text', value: technology.demand.try(:round, 2), data: { type: 'demand'} }
+        .clearfix
 
     - if technology.whitelisted?('input_capacity')
       .editable.text{class: 'carrier_capacity'}
@@ -67,10 +69,11 @@
         %input.form-control{type: 'text', value: technology.carrier_capacity.try(:round, 4), disabled: "disabled", data: { type: 'carrier_capacity' } }
         .clearfix
 
-    .editable.text{class: 'volume'}
-      %span Volume [kWh]
-      %input.form-control{type: 'text', value: technology.volume, data: { type: 'volume' }}
-      .clearfix
+    - if technology.whitelisted?('volume')
+      .editable.text{class: 'volume'}
+        %span Volume [kWh]
+        %input.form-control{type: 'text', value: technology.volume, data: { type: 'volume' }}
+        .clearfix
 
     .editable.text{class: 'units'}
       %span Units
@@ -78,11 +81,11 @@
       .clearfix
 
     - InstalledTechnology.attribute_set.each do |attribute|
-      - if attribute.options[:hidden]
+      - if attribute.options[:hidden] || ! technology.whitelisted?(attribute.name)
         .editable.hidden{class: attribute.name}
           %input.form-control{type: 'text', value: technology.public_send(attribute.name), data: { type: attribute.name } }
 
-      - if attribute.options[:advanced]
+      - if attribute.options[:advanced] && technology.whitelisted?(attribute.name)
         .editable.advanced.hidden{class: attribute.name}
           %span= t(:"installed_technology_attributes.#{ attribute.name }")
           %input.form-control{type: 'text', value: technology.public_send(attribute.name), data: { type: attribute.name } }

--- a/db/migrate/20160718140018_set_default_cop_on_existing_leses.rb
+++ b/db/migrate/20160718140018_set_default_cop_on_existing_leses.rb
@@ -1,0 +1,36 @@
+class SetDefaultCopOnExistingLeses < ActiveRecord::Migration
+  def up
+    count   = TestingGround.count
+    updated = 0
+
+    TestingGround.find_each.with_index do |les, index|
+      changed = false
+
+      les.technology_profile.each_tech do |tech|
+        next if tech.whitelisted?(:performance_coefficient)
+
+        cop = tech.performance_coefficient
+
+        if ! cop.nil? && cop.to_f != 1.0
+          changed = true
+          tech.performance_coefficient = 1.0
+        end
+      end
+
+      if changed
+        updated += 1
+        les.save(validate: false)
+      end
+
+      if ((index + 1) % 50).zero? || (index + 1) == count
+        puts "Done #{ index + 1 } of #{ count }"
+      end
+    end
+
+    puts "Finished. #{ updated } fixed."
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160714083258) do
+ActiveRecord::Schema.define(version: 20160718140018) do
 
   create_table "asset_lists", force: true do |t|
     t.integer  "testing_ground_id"

--- a/db/static/technologies/base_load.yml
+++ b/db/static/technologies/base_load.yml
@@ -13,13 +13,9 @@ technology_component_behavior:
 whitelisted_attributes:
   - demand
   - initial_investment
-  - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
-  - output_capacity
-  - performance_coefficient
   - profile
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/base_load_buildings.yml
+++ b/db/static/technologies/base_load_buildings.yml
@@ -14,13 +14,9 @@ technology_component_behavior:
 whitelisted_attributes:
   - demand
   - initial_investment
-  - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
-  - output_capacity
-  - performance_coefficient
   - profile
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/base_load_edsn.yml
+++ b/db/static/technologies/base_load_edsn.yml
@@ -11,13 +11,9 @@ visible: false
 whitelisted_attributes:
   - demand
   - initial_investment
-  - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
-  - output_capacity
-  - performance_coefficient
   - profile
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/buffer_space_heating.yml
+++ b/db/static/technologies/buffer_space_heating.yml
@@ -28,7 +28,6 @@ whitelisted_attributes:
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - profile
   - technical_lifetime
   - units

--- a/db/static/technologies/buffer_water_heating.yml
+++ b/db/static/technologies/buffer_water_heating.yml
@@ -31,7 +31,6 @@ whitelisted_attributes:
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - profile
   - technical_lifetime
   - units

--- a/db/static/technologies/congestion_battery.yml
+++ b/db/static/technologies/congestion_battery.yml
@@ -10,14 +10,12 @@ exists_as_technology_in_etengine: false
 profile_required: false
 whitelisted_attributes:
   - congestion_reserve_percentage
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - technical_lifetime
   - units
   - volume

--- a/db/static/technologies/energy_flexibility_p2g_electricity.yml
+++ b/db/static/technologies/energy_flexibility_p2g_electricity.yml
@@ -17,14 +17,12 @@ importable_attributes:
 
 profile_required: false
 whitelisted_attributes:
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - technical_lifetime
   - units
   - volume

--- a/db/static/technologies/generic.yml
+++ b/db/static/technologies/generic.yml
@@ -11,7 +11,6 @@ whitelisted_attributes:
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - profile
   - technical_lifetime
   - units

--- a/db/static/technologies/generic_must_run.yml
+++ b/db/static/technologies/generic_must_run.yml
@@ -12,7 +12,6 @@ whitelisted_attributes:
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - profile
   - technical_lifetime
   - units

--- a/db/static/technologies/households_flexibility_p2h_electricity.yml
+++ b/db/static/technologies/households_flexibility_p2h_electricity.yml
@@ -17,7 +17,6 @@ importable_attributes:
   - variable_operation_and_maintenance_costs_per_full_load_hour
 
 whitelisted_attributes:
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour

--- a/db/static/technologies/households_flexibility_p2p_electricity.yml
+++ b/db/static/technologies/households_flexibility_p2p_electricity.yml
@@ -18,14 +18,12 @@ importable_attributes:
 
 profile_required: false
 whitelisted_attributes:
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - technical_lifetime
   - units
   - volume

--- a/db/static/technologies/households_solar_pv_solar_radiation.yml
+++ b/db/static/technologies/households_solar_pv_solar_radiation.yml
@@ -16,14 +16,11 @@ importable_attributes:
   - variable_operation_and_maintenance_costs_per_full_load_hour
 
 whitelisted_attributes:
-  - demand
   - initial_investment
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - profile
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_combined_network_gas.yml
+++ b/db/static/technologies/households_space_heater_combined_network_gas.yml
@@ -15,15 +15,12 @@ importable_attributes:
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_district_heating_steam_hot_water.yml
+++ b/db/static/technologies/households_space_heater_district_heating_steam_hot_water.yml
@@ -23,8 +23,6 @@ whitelisted_attributes:
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_electricity.yml
+++ b/db/static/technologies/households_space_heater_electricity.yml
@@ -24,8 +24,6 @@ whitelisted_attributes:
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_heatpump_air_water_electricity.yml
+++ b/db/static/technologies/households_space_heater_heatpump_air_water_electricity.yml
@@ -19,7 +19,6 @@ importable_attributes:
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -30,4 +29,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_heatpump_ground_water_electricity.yml
+++ b/db/static/technologies/households_space_heater_heatpump_ground_water_electricity.yml
@@ -19,7 +19,6 @@ importable_attributes:
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -30,4 +29,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_hybrid_heatpump_air_water_electricity.yml
+++ b/db/static/technologies/households_space_heater_hybrid_heatpump_air_water_electricity.yml
@@ -14,7 +14,6 @@ importable_attributes:
 visible: false
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -25,4 +24,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_hybrid_heatpump_air_water_electricity_electricity.yml
+++ b/db/static/technologies/households_space_heater_hybrid_heatpump_air_water_electricity_electricity.yml
@@ -9,7 +9,6 @@ defaults:
 exists_as_technology_in_etengine: false
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -20,4 +19,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_hybrid_heatpump_air_water_electricity_gas.yml
+++ b/db/static/technologies/households_space_heater_hybrid_heatpump_air_water_electricity_gas.yml
@@ -9,7 +9,6 @@ defaults:
 exists_as_technology_in_etengine: false
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -20,4 +19,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_micro_chp_network_gas.yml
+++ b/db/static/technologies/households_space_heater_micro_chp_network_gas.yml
@@ -8,15 +8,12 @@ exists_as_technology_in_etengine: false
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_space_heater_network_gas.yml
+++ b/db/static/technologies/households_space_heater_network_gas.yml
@@ -15,15 +15,12 @@ importable_attributes:
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_combined_network_gas.yml
+++ b/db/static/technologies/households_water_heater_combined_network_gas.yml
@@ -7,15 +7,12 @@ defaults:
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_district_heating_steam_hot_water.yml
+++ b/db/static/technologies/households_water_heater_district_heating_steam_hot_water.yml
@@ -24,8 +24,6 @@ whitelisted_attributes:
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_fuel_cell_chp_network_gas.yml
+++ b/db/static/technologies/households_water_heater_fuel_cell_chp_network_gas.yml
@@ -4,15 +4,12 @@ carrier: gas
 visible: false
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_heatpump_air_water_electricity.yml
+++ b/db/static/technologies/households_water_heater_heatpump_air_water_electricity.yml
@@ -19,7 +19,6 @@ importable_attributes:
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -30,4 +29,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_heatpump_ground_water_electricity.yml
+++ b/db/static/technologies/households_water_heater_heatpump_ground_water_electricity.yml
@@ -19,7 +19,6 @@ importable_attributes:
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -30,4 +29,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_hybrid_heatpump_air_water_electricity.yml
+++ b/db/static/technologies/households_water_heater_hybrid_heatpump_air_water_electricity.yml
@@ -14,7 +14,6 @@ importable_attributes:
 visible: false
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -25,4 +24,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_hybrid_heatpump_air_water_electricity_electricity.yml
+++ b/db/static/technologies/households_water_heater_hybrid_heatpump_air_water_electricity_electricity.yml
@@ -9,7 +9,6 @@ defaults:
 exists_as_technology_in_etengine: false
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -20,4 +19,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_hybrid_heatpump_air_water_electricity_gas.yml
+++ b/db/static/technologies/households_water_heater_hybrid_heatpump_air_water_electricity_gas.yml
@@ -9,7 +9,6 @@ defaults:
 exists_as_technology_in_etengine: false
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
@@ -20,4 +19,3 @@ whitelisted_attributes:
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_micro_chp_network_gas.yml
+++ b/db/static/technologies/households_water_heater_micro_chp_network_gas.yml
@@ -8,15 +8,12 @@ exists_as_technology_in_etengine: false
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_network_gas.yml
+++ b/db/static/technologies/households_water_heater_network_gas.yml
@@ -7,15 +7,12 @@ defaults:
 
 whitelisted_attributes:
   - buffer
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/households_water_heater_resistive_electricity.yml
+++ b/db/static/technologies/households_water_heater_resistive_electricity.yml
@@ -23,8 +23,6 @@ whitelisted_attributes:
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - position_relative_to_buffer
   - technical_lifetime
   - units
-  - volume

--- a/db/static/technologies/transport_car_using_electricity.yml
+++ b/db/static/technologies/transport_car_using_electricity.yml
@@ -21,14 +21,12 @@ importable_gqueries:
   initial_investment: electric_cars_additional_costs
 
 whitelisted_attributes:
-  - demand
   - initial_investment
   - input_capacity
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
   - om_costs_per_year
   - output_capacity
-  - performance_coefficient
   - profile
   - technical_lifetime
   - units


### PR DESCRIPTION
This is note *quite* what was asked for in #1292, because it *hides* COP – rather than disables it – for technologies on which it is not supported. I think that's an acceptable compromise in the name of simplicity, since you can still tell that efficiency is 100% by comparing the input and output capacities. If you feel strongly that it should be visible, let me know. I intend to revisit this with "Input Validation".

I have also hidden `demand`, `volume`, and capacity attributes in some cases. For example, technologies which belong to heat buffers should not allow the visitor to set a `demand` or `volume` (those are set on the buffer). Other technologies, such as Households, have their load set by ``demand`` and I felt that also showing a capacity was confusing (and the two attributes would conflict).

* Removed `demand` and `volume` from all heating technologies.

* Removed COP from all technologies except:
  * Heat pumps
  * Hybrid heat pumps
  * Power-to-heat

* From base loads, removed capacity and `volume`.

* From P2G, removed `demand`.

* From the neighbourhood battery, removed `demand`.

* From power-to-heat, removed `demand`.

* P2P batteries, removed `demand`.

* From solar PV, removed `demand` and `volume`.

* From the electric vehicle, removed `demand`.

@ChaelKruip I'd appreciate a critical eye over these changes; I don't think they'll be controversial, but just in case...