### PR TITLE
Fixes: #540

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'unicorn'
 # Background processor
 gem 'daemons'
 gem 'delayed_job_active_record'
+gem 'delayed-plugins-airbrake'
 
 # Caching
 gem 'msgpack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,9 @@ GEM
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     deep_merge (1.0.1)
+    delayed-plugins-airbrake (1.1.0)
+      airbrake
+      delayed_job
     delayed_job (4.0.6)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.0.3)
@@ -397,6 +400,7 @@ DEPENDENCIES
   config
   daemons
   database_cleaner
+  delayed-plugins-airbrake
   delayed_job_active_record
   devise
   dry-equalizer

--- a/app/controllers/business_cases_controller.rb
+++ b/app/controllers/business_cases_controller.rb
@@ -25,7 +25,8 @@ class BusinessCasesController < ResourceController
   end
 
   def render_summary
-    @business_case_summary = Finance::BusinessCaseSummary.new(@business_case).summarize
+    @business_case_summary =
+      Finance::BusinessCaseSummary.new(@business_case).summarize
   end
 
   def update

--- a/app/models/import/base_builder.rb
+++ b/app/models/import/base_builder.rb
@@ -1,5 +1,5 @@
 class Import
-  class Builder
+  class BaseBuilder
     def initialize(gqueries, id:, scaling:, **)
       @gqueries    = gqueries
       @scenario_id = id

--- a/app/models/import/buildings_builder.rb
+++ b/app/models/import/buildings_builder.rb
@@ -1,5 +1,5 @@
 class Import
-  class BuildingsBuilder < Builder
+  class BuildingsBuilder < BaseBuilder
     #
     # Given a scenario, returns the amount of buildings for the current scenario
     # Also calculates the average demand of a single building

--- a/app/models/import/composite_builder.rb
+++ b/app/models/import/composite_builder.rb
@@ -1,5 +1,5 @@
 class Import
-  class CompositeBuilder < Builder
+  class CompositeBuilder < BaseBuilder
     include Scaling
 
     COMPOSITE_ATTRS = %w(name key default_demand)

--- a/app/models/import/default_technology_builder.rb
+++ b/app/models/import/default_technology_builder.rb
@@ -1,5 +1,5 @@
 class Import
-  class DefaultTechnologyBuilder < Builder
+  class DefaultTechnologyBuilder < BaseBuilder
     include Filters
 
     def build(response)

--- a/app/models/import/electric_vehicle_builder.rb
+++ b/app/models/import/electric_vehicle_builder.rb
@@ -1,5 +1,5 @@
 class Import
-  class ElectricVehicleBuilder < Builder
+  class ElectricVehicleBuilder < BaseBuilder
     EV_KEY = 'transport_car_using_electricity'
 
     def build(response)

--- a/app/models/import/house_builder.rb
+++ b/app/models/import/house_builder.rb
@@ -1,5 +1,5 @@
 class Import
-  class HouseBuilder < Builder
+  class HouseBuilder < BaseBuilder
     include Scaling
 
     #

--- a/app/models/import/hybrid_builder.rb
+++ b/app/models/import/hybrid_builder.rb
@@ -1,5 +1,5 @@
 class Import
-  class HybridBuilder < Builder
+  class HybridBuilder < BaseBuilder
     include Filters
     # The hybrid expanders is a class that expands hybrid technologies.
     # It assumes the following:

--- a/app/models/import/resistive_water_heater_builder.rb
+++ b/app/models/import/resistive_water_heater_builder.rb
@@ -7,7 +7,7 @@ class Import
   # we need to ensure that the Moses LES has at least 25% of households with an
   # electric heater. If the LES should fall short of that, we add extra space
   # heater electricity technologies to compensate.
-  class ResistiveWaterHeaterBuilder < Builder
+  class ResistiveWaterHeaterBuilder < BaseBuilder
     include Scaling
 
     TECH_KEY    = 'households_water_heater_resistive_electricity'.freeze

--- a/app/services/finance/business_case_summary.rb
+++ b/app/services/finance/business_case_summary.rb
@@ -7,6 +7,8 @@ module Finance
     end
 
     def summarize
+      return [] if financials.nil?
+
       financials_without_freeform.each_with_index.map do |financial_rule, index|
         summarize_rule(financial_rule, index)
       end

--- a/app/views/business_cases/_table.html.haml
+++ b/app/views/business_cases/_table.html.haml
@@ -1,14 +1,11 @@
 %div.compare
-  - if business_case_rows
+  - if business_case_rows && business_case_rows.size > 0
     %span= "Compare business case from #{@testing_ground.name} with"
     %span.compare
       = select_tag "compare", options_for_testing_grounds(@testing_ground), include_blank: true, class: "form-control", data: { compare_url: compare_with_testing_ground_business_case_path(@testing_ground, @business_case) }
 
-  - else
-    Business case
-
 #business_case_table{data: { url: data_testing_ground_business_case_path(@testing_ground, @business_case), finish_url: render_summary_testing_ground_business_case_path(@testing_ground, @business_case) } }
-  - if business_case_rows
+  - if business_case_rows && business_case_rows.size > 0
     %table.table.table-bordered.compare
       %thead
         %tr
@@ -57,6 +54,12 @@
 
     %span.loading-spinner
       = image_tag 'wait.gif'
+
+  - elsif business_case_rows.empty?
+    .alert.alert-danger
+      Something went wrong with the business case calculation.
+
+    %br
 
   - else
     Loading ..

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,4 +1,7 @@
+require 'delayed-plugins-airbrake'
+
 Delayed::Worker.delay_jobs = !Rails.env.test?
 Delayed::Worker.max_attempts = 3
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+Delayed::Worker.plugins << Delayed::Plugins::Airbrake::Plugin

--- a/spec/controllers/business_cases_controller_spec.rb
+++ b/spec/controllers/business_cases_controller_spec.rb
@@ -97,4 +97,36 @@ RSpec.describe BusinessCasesController do
       expect(JSON.parse(response.body)).to eq({ "valid" => true })
     end
   end
+
+  describe "render summary" do
+    describe "all is fine" do
+      let(:business_case) {
+        FactoryGirl.create(:business_case, testing_ground: testing_ground)
+      }
+
+      it "gives a 200 OK" do
+        post :render_summary,
+          testing_ground_id: testing_ground.id,
+          id: business_case.id,
+          format: :js
+
+        expect(response).to be_success
+      end
+    end
+
+    describe "raises an error" do
+      let(:business_case) {
+        FactoryGirl.create(:business_case, testing_ground: testing_ground, financials: nil)
+      }
+
+      it "gives a 200 OK" do
+        post :render_summary,
+          testing_ground_id: testing_ground.id,
+          id: business_case.id,
+          format: :js
+
+        expect(response).to be_success
+      end
+    end
+  end
 end


### PR DESCRIPTION
Raise an error when the financials are blank. As explained in #540 the problem arises from another calculation error. The error is usually visible in the DelayedJob queue.