### PR TITLE
Recalculate a user's business case when the market model is updated

### DIFF
--- a/app/controllers/market_models_controller.rb
+++ b/app/controllers/market_models_controller.rb
@@ -33,7 +33,7 @@ class MarketModelsController < ResourceController
   end
 
   def update
-    if @market_model.update(market_model_params)
+    if MarketModel::Update.update(@market_model, market_model_params)
       redirect_to market_model_path(@market_model)
     else
       render :edit

--- a/app/services/market_model/update.rb
+++ b/app/services/market_model/update.rb
@@ -1,0 +1,22 @@
+class MarketModel::Update
+  def self.update(market_model, market_model_params)
+    new(market_model, market_model_params).update
+  end
+
+  def initialize(market_model, market_model_params)
+    @market_model = market_model
+    @market_model_params = market_model_params
+  end
+
+  def update
+    BusinessCase.where(testing_ground: testing_grounds).each(&:clear_job!)
+
+    @market_model.update_attributes(@market_model_params)
+  end
+
+  private
+
+  def testing_grounds
+    TestingGround.where(market_model: @market_model)
+  end
+end

--- a/spec/controllers/market_models_controller_spec.rb
+++ b/spec/controllers/market_models_controller_spec.rb
@@ -34,4 +34,39 @@ RSpec.describe MarketModelsController do
       expect(response).to redirect_to(new_user_session_path)
     end
   end
+
+  describe "#update" do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:market_model) { FactoryGirl.create(:market_model, user: user) }
+    let(:business_cases) {
+      BusinessCase.where(testing_ground: TestingGround.where(market_model: market_model))
+    }
+
+    let(:control_group) {
+      FactoryGirl.create(:business_case, job_id: 2)
+    }
+
+    before do
+      sign_in(:user, user)
+
+      3.times do
+        testing_ground = FactoryGirl.create(:testing_ground,
+          market_model: market_model)
+
+        FactoryGirl.create(:business_case,
+                           testing_ground: testing_ground, job_id: 1)
+      end
+
+      patch :update, id: market_model.id, market_model: {
+        name: "test", public: true, interactions: [] }
+    end
+
+    it "should recalculate the business case for all LES's with the same market model id as the given id" do
+      expect(business_cases.pluck(:job_id)).to eq([nil, nil, nil])
+    end
+
+    it "should not change other business case job id's" do
+      expect(control_group.job_id).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
Fixes: #1422