### PR TITLE
Only make it possible to save non-blank whitelisted attributes to the database

### DIFF
--- a/app/models/installed_technology.rb
+++ b/app/models/installed_technology.rb
@@ -278,12 +278,16 @@ class InstalledTechnology
     position_relative_to_buffer.present? || carrier == :hybrid
   end
 
+  def deletable(key, value)
+    value.blank? || !technology.whitelisted.include?(key.to_s)
+  end
+
   def as_json(*)
-    super.delete_if { |_, v| v.blank? }
+    super.delete_if(&method(:deletable))
   end
 
   def to_h
-    super.delete_if { |_, v| v.blank? }
+    super.delete_if(&method(:deletable))
   end
 
   private

--- a/app/models/technology.rb
+++ b/app/models/technology.rb
@@ -99,6 +99,10 @@ class Technology < ActiveHash::Base
     attributes[:technologies] || []
   end
 
+  def whitelisted
+    whitelisted_attributes << 'type'
+  end
+
   def options_for_names
     {
       position_relative_to_buffer: defaults['position_relative_to_buffer'],

--- a/db/static/technologies/buffer_space_heating.yml
+++ b/db/static/technologies/buffer_space_heating.yml
@@ -20,6 +20,8 @@ technologies:
   - households_space_heater_hybrid_heatpump_air_water_electricity
 
 whitelisted_attributes:
+  - composite
+  - composite_value
   - demand
   - initial_investment
   - input_capacity

--- a/db/static/technologies/buffer_water_heating.yml
+++ b/db/static/technologies/buffer_water_heating.yml
@@ -22,6 +22,8 @@ technologies:
   - households_water_heater_resistive_electricity
 
 whitelisted_attributes:
+  - composite
+  - composite_value
   - demand
   - initial_investment
   - input_capacity

--- a/db/static/technologies/households_water_heater_resistive_electricity.yml
+++ b/db/static/technologies/households_water_heater_resistive_electricity.yml
@@ -21,6 +21,7 @@ importable_attributes:
 
 whitelisted_attributes:
   - buffer
+  - full_load_hours
   - initial_investment
   - input_capacity
   - om_costs_per_year

--- a/spec/fixtures/static/technologies/buffer_space_heating.yml
+++ b/spec/fixtures/static/technologies/buffer_space_heating.yml
@@ -11,6 +11,8 @@ defaults:
 exists_as_technology_in_etengine: false
 expandable: true
 whitelisted_attributes:
+  - composite
+  - composite_value
   - demand
   - initial_investment
   - input_capacity
@@ -23,6 +25,7 @@ whitelisted_attributes:
   - technical_lifetime
   - units
   - volume
+
 technologies:
   - households_space_heater_district_heating_steam_hot_water
   - households_space_heater_electricity
@@ -32,5 +35,6 @@ technologies:
   - households_space_heater_combined_network_gas
   - households_space_heater_hybrid_heatpump_air_water_electricity_gas
   - households_space_heater_hybrid_heatpump_air_water_electricity_electricity
+
 importable_gqueries:
   demand: etmoses_space_heating_buffer_demand

--- a/spec/fixtures/static/technologies/buffer_water_heating.yml
+++ b/spec/fixtures/static/technologies/buffer_water_heating.yml
@@ -23,6 +23,8 @@ technologies:
   - households_water_heater_district_heating_steam_hot_water
 
 whitelisted_attributes:
+  - composite
+  - composite_value
   - demand
   - initial_investment
   - input_capacity

--- a/spec/fixtures/static/technologies/four.yml
+++ b/spec/fixtures/static/technologies/four.yml
@@ -6,7 +6,6 @@ visible: true
 composite: false
 expandable: false
 whitelisted_attributes:
-  - capacity
   - demand
   - initial_investment
   - input_capacity

--- a/spec/fixtures/static/technologies/households_flexibility_p2p_electricity.yml
+++ b/spec/fixtures/static/technologies/households_flexibility_p2p_electricity.yml
@@ -8,6 +8,7 @@ defaults:
   capacity: 4.4
 expandable: true
 profile_required: false
+
 importable_attributes:
   - fixed_operation_and_maintenance_costs_per_year
   - full_load_hours
@@ -17,7 +18,9 @@ importable_attributes:
   - technical_lifetime
   - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour
   - variable_operation_and_maintenance_costs_per_full_load_hour
+
 whitelisted_attributes:
+  - capacity
   - demand
   - initial_investment
   - input_capacity

--- a/spec/fixtures/static/technologies/households_solar_pv_solar_radiation.yml
+++ b/spec/fixtures/static/technologies/households_solar_pv_solar_radiation.yml
@@ -6,6 +6,7 @@ visible: true
 composite: false
 defaults:
   capacity: -1.6
+
 expandable: true
 importable_attributes:
   - electricity_output_capacity
@@ -15,8 +16,11 @@ importable_attributes:
   - technical_lifetime
   - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour
   - variable_operation_and_maintenance_costs_per_full_load_hour
+
 whitelisted_attributes:
+  - capacity
   - demand
+  - full_load_hours
   - initial_investment
   - om_costs_for_ccs_per_full_load_hour
   - om_costs_per_full_load_hour
@@ -24,6 +28,7 @@ whitelisted_attributes:
   - output_capacity
   - performance_coefficient
   - profile
+  - profile_key
   - technical_lifetime
   - units
   - volume

--- a/spec/fixtures/static/technologies/households_space_heater_heatpump_air_water_electricity.yml
+++ b/spec/fixtures/static/technologies/households_space_heater_heatpump_air_water_electricity.yml
@@ -20,6 +20,7 @@ importable_attributes:
 
 whitelisted_attributes:
   - buffer
+  - capacity
   - demand
   - initial_investment
   - input_capacity

--- a/spec/fixtures/static/technologies/one.yml
+++ b/spec/fixtures/static/technologies/one.yml
@@ -6,7 +6,6 @@ visible: true
 composite: false
 expandable: false
 whitelisted_attributes:
-  - capacity
   - demand
   - initial_investment
   - input_capacity

--- a/spec/fixtures/static/technologies/three.yml
+++ b/spec/fixtures/static/technologies/three.yml
@@ -6,7 +6,6 @@ visible: true
 composite: false
 expandable: false
 whitelisted_attributes:
-  - capacity
   - demand
   - initial_investment
   - input_capacity

--- a/spec/fixtures/static/technologies/two.yml
+++ b/spec/fixtures/static/technologies/two.yml
@@ -6,7 +6,6 @@ visible: true
 composite: false
 expandable: false
 whitelisted_attributes:
-  - capacity
   - demand
   - initial_investment
   - input_capacity

--- a/spec/models/installed_technology_spec.rb
+++ b/spec/models/installed_technology_spec.rb
@@ -296,4 +296,24 @@ RSpec.describe InstalledTechnology do
       expect(technology.components.map(&:class)[0]).to eq(InstalledTechnology)
     end
   end
+
+  describe "convert to a hash" do
+    it "doesn't include blank attributes" do
+      expect(InstalledTechnology.new(capacity: nil).to_h).to eq({
+        performance_coefficient: 1, units: 1, type: 'generic'
+      })
+    end
+
+    it "doesn't include non-whitelisted attributes" do
+      expect(InstalledTechnology.new(buffer: 'test').to_h).to eq({
+        performance_coefficient: 1, units: 1, type: 'generic'
+      })
+    end
+
+    it "does include non-blank whitelisted attributes" do
+      expect(InstalledTechnology.new(demand: 1.0).to_h).to eq({
+        performance_coefficient: 1, units: 1, type: 'generic', demand: 1.0
+      })
+    end
+  end
 end # InstalledTechnology

--- a/spec/models/technology_list_spec.rb
+++ b/spec/models/technology_list_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe TechnologyList do
   let(:hash) { YAML.load(<<-YML.strip_heredoc) }
     ---
     lv1:
-    - type: One
+    - type: one
       capacity: 1.2
       profile_key: 'profile_1'
-    - type: Two
+    - type: two
       capacity: -0.3
       profile_key: 'profile_1'
     lv2:
-    - type: Three
+    - type: three
       capacity: 3.2
       profile_key: 'profile_1'
-    - type: Four
+    - type: four
       capacity: 0.1
       profile_key: 'profile_1'
       components:
@@ -37,14 +37,14 @@ RSpec.describe TechnologyList do
     end
 
     it 'includes technologies' do
-      expect(parsed.detect { |row| row['type'] == 'One' }).to be
-      expect(parsed.detect { |row| row['type'] == 'Two' }).to be
-      expect(parsed.detect { |row| row['type'] == 'Three' }).to be
-      expect(parsed.detect { |row| row['type'] == 'Four' }).to be
+      expect(parsed.detect { |row| row['type'] == 'one' }).to be
+      expect(parsed.detect { |row| row['type'] == 'two' }).to be
+      expect(parsed.detect { |row| row['type'] == 'three' }).to be
+      expect(parsed.detect { |row| row['type'] == 'four' }).to be
     end
 
     it 'includes technology attributes' do
-      tech = parsed.detect { |row| row['type'] == 'Two' }
+      tech = parsed.detect { |row| row['type'] == 'two' }
 
       expect(tech['connection']).to eq('lv1')
       expect(tech['capacity']).to eq('-0.3')
@@ -112,11 +112,11 @@ RSpec.describe TechnologyList do
     end
 
     it 'includes the defined technologies' do
-      expect(list['lv1'][0].type).to eq('One')
-      expect(list['lv1'][1].type).to eq('Two')
+      expect(list['lv1'][0].type).to eq('one')
+      expect(list['lv1'][1].type).to eq('two')
 
-      expect(list['lv2'][0].type).to eq('Three')
-      expect(list['lv2'][1].type).to eq('Four')
+      expect(list['lv2'][0].type).to eq('three')
+      expect(list['lv2'][1].type).to eq('four')
     end
   end # .from_hash
 


### PR DESCRIPTION
This is meant to only save the whitelisted attributes to the database. If they are not whitelisted they are not saved. 

WARNING; some technologies are not yet tested, and might give some complications when merging. 