### PR TITLE
User may customise heat capacity per connection

### DIFF
--- a/app/controllers/testing_grounds_controller.rb
+++ b/app/controllers/testing_grounds_controller.rb
@@ -192,7 +192,7 @@ class TestingGroundsController < ResourceController
       .require(:testing_ground)
       .permit([:name, :technology_profile, :public, :behavior_profile_id,
                :parent_scenario_id, :technology_profile_csv, :scenario_id,
-               :topology_id, :market_model_id])
+               :topology_id, :market_model_id, :central_heat_buffer_capacity])
 
     if tg_params[:technology_profile_csv]
       tg_params.delete(:technology_profile)

--- a/app/models/network/builders/heat.rb
+++ b/app/models/network/builders/heat.rb
@@ -35,7 +35,11 @@ module Network
         @park = Network::Heat::ProductionPark.new(
           must_run:         must_run,
           dispatchable:     dispatchable,
-          # https://github.com/quintel/etmoses/issues/971
+          # Normal heat producers may fill the buffer up to base_volume (by
+          # default, 10kWh), but must-runs may add more to the buffer so as not
+          # to waste excess energy (17.8kWh assuming base volume of 10kWh).
+          #
+          # See https://github.com/quintel/etmoses/issues/971
           volume:           base_volume,
           amplified_volume: base_volume * 1.78
         )

--- a/app/models/network/builders/heat.rb
+++ b/app/models/network/builders/heat.rb
@@ -3,10 +3,12 @@ require_relative '../builders'
 module Network
   module Builders
     class Heat
-      def self.build(tree, techs = TechnologyList.new, heat_sources = nil)
+      def self.build(tree,techs = TechnologyList.new, sources = nil, opts = {})
         new(
-          tree, techs,
-          heat_sources ? HeatSourceListDecorator.new(heat_sources).decorate : []
+          tree,
+          techs,
+          sources ? HeatSourceListDecorator.new(sources).decorate : [],
+          opts
         ).to_graph
       end
 
@@ -16,10 +18,11 @@ module Network
 
       private
 
-      def initialize(tree, techs, heat_sources)
-        @tree         = tree
-        @techs        = techs
+      def initialize(tree, techs, heat_sources, opts)
+        @tree = tree
+        @techs = techs
         @heat_sources = heat_sources
+        @capacity_per_conn = opts[:central_heat_buffer_capacity] || 10.0
       end
 
       def build_graph
@@ -27,12 +30,14 @@ module Network
         dispatchable, must_run =
           sources_to_producers(@heat_sources).partition(&:dispatchable?)
 
+        base_volume = number_of_connections * 4 * @capacity_per_conn
+
         @park = Network::Heat::ProductionPark.new(
           must_run:         must_run,
           dispatchable:     dispatchable,
           # https://github.com/quintel/etmoses/issues/971
-          volume:           number_of_connections * 4 * 10.0,
-          amplified_volume: number_of_connections * 4 * 17.78
+          volume:           base_volume,
+          amplified_volume: base_volume * 1.78
         )
 
         @graph = Graph.new(:heat)

--- a/app/models/testing_ground.rb
+++ b/app/models/testing_ground.rb
@@ -26,6 +26,9 @@ class TestingGround < ActiveRecord::Base
   validates :topology, presence: true
   validates :name, presence: true, length: { maximum: 100 }
 
+  validates :central_heat_buffer_capacity,
+    numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+
   validate  :validate_technology_profile_connections, if: :topology
   validate  :validate_technology_profile_types
   validate  :validate_technology_profile_units
@@ -121,7 +124,8 @@ class TestingGround < ActiveRecord::Base
     Network::Builders.for(carrier).build(
       topology.graph,
       TechnologyProfileCalculationDecorator.new(technology_profile).decorate,
-      heat_source_list
+      heat_source_list,
+      central_heat_buffer_capacity: central_heat_buffer_capacity
     )
   end
 

--- a/app/views/testing_grounds/_general_form.html.haml
+++ b/app/views/testing_grounds/_general_form.html.haml
@@ -36,3 +36,9 @@
     = form.label :behavior_profile_id, 'Behavior profile'
     .temperature-profile
       = form.select :behavior_profile_id, options_for_behavior_profiles(testing_ground.behavior_profile_id), {include_blank: true}, class: 'form-control'
+
+  .form-group
+    = form.label :central_heat_buffer_capacity, 'Central heat buffer capacity per connection'
+    .input-group(style="width: 150px")
+      = form.number_field :central_heat_buffer_capacity, class: 'form-control', placeholder: '10.0', step: 0.1
+      .input-group-addon kWh

--- a/db/migrate/20161024122719_add_central_heat_buffer_capacity_attribute.rb
+++ b/db/migrate/20161024122719_add_central_heat_buffer_capacity_attribute.rb
@@ -1,0 +1,6 @@
+class AddCentralHeatBufferCapacityAttribute < ActiveRecord::Migration
+  def change
+    add_column :testing_grounds, :central_heat_buffer_capacity, :float,
+      after: :behavior_profile_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160825140422) do
+ActiveRecord::Schema.define(version: 20161024122719) do
 
   create_table "asset_lists", force: true do |t|
     t.integer  "testing_ground_id"
@@ -142,20 +142,21 @@ ActiveRecord::Schema.define(version: 20160825140422) do
   end
 
   create_table "testing_grounds", force: true do |t|
-    t.text     "technology_profile",  limit: 16777215
+    t.text     "technology_profile",           limit: 16777215
     t.integer  "user_id"
     t.integer  "topology_id"
     t.integer  "market_model_id"
     t.integer  "behavior_profile_id"
-    t.boolean  "public",                               default: true, null: false
+    t.float    "central_heat_buffer_capacity", limit: 24
+    t.boolean  "public",                                        default: true, null: false
     t.integer  "parent_scenario_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "cache_updated_at"
-    t.string   "name",                limit: 100,      default: "",   null: false
+    t.string   "name",                         limit: 100,      default: "",   null: false
     t.integer  "scenario_id"
-    t.integer  "range_start",                          default: 0
-    t.integer  "range_end",                            default: 672
+    t.integer  "range_start",                                   default: 0
+    t.integer  "range_end",                                     default: 672
   end
 
   create_table "topologies", force: true do |t|

--- a/spec/models/network/builders/heat_spec.rb
+++ b/spec/models/network/builders/heat_spec.rb
@@ -2,49 +2,71 @@ require 'rails_helper'
 
 module Network::Builders
   RSpec.describe Heat do
-    let(:graph) { Heat.build(tree, list, sources) }
-    let(:techs) { {} }
-    let(:list)  { TechnologyList.from_hash(techs) }
-
-    let(:tree) {{
-      name: :parent,
-      children: [{ name: :child1 }, { name: :child2 }]
-    }}
-
-    let(:sources_hash) {
-      [{
-        "total_initial_investment" => 800.0,
-        "om_costs_per_year" => 25.0,
-        "technical_lifetime" => 30.0,
-        "marginal_costs" => 0.0,
-        "distance" => 1,
-        "units" => 1,
-        "key" => "households_collective_chp_biogas",
-        "heat_production" => 0.0,
-        "priority" => 0
-      },
+    let(:techs) do
       {
-        "distance" => 1,
-        "key" => "central_heat_network_dispatchable",
-        "name" => "Geothermal",
-        "units" => 0.0,
-        "heat_capacity" => 3.71,
-        "heat_production" => 0.0,
-        "total_initial_investment" => 1000.0,
-        "technical_lifetime" => 25.0,
-        "om_costs_per_year" => 7.55,
-        "marginal_costs" => 0.0,
-        "priority" => 1
-      }]
-    }
+        child1: [{
+          type: 'households_water_heater_district_heating_steam_hot_water',
+          units: 10
+        }]
+      }
+    end
 
-    let(:sources) { HeatSourceList.new(source_list: sources_hash) }
+    let(:list) { TechnologyList.from_hash(techs) }
+
+    let(:tree) do
+      { name: :parent, children: [{ name: :child1 }, { name: :child2 }] }
+    end
+
+    let(:sources_hash) do
+      [{
+        distance: 1,
+        units: 1,
+        key: 'households_collective_chp_biogas',
+        heat_production: 0.0,
+        priority: 0
+      }, {
+        distance: 1,
+        key: 'central_heat_network_dispatchable',
+        units: 0.0,
+        heat_capacity: 3.71,
+        heat_production: 0.0,
+        priority: 1
+      }]
+    end
+
+    let(:sources) { HeatSourceList.new(asset_list: sources_hash) }
+
+    let(:park) { graph.head.get(:park) }
 
     # --------------------------------------------------------------------------
 
-    context 'trying something' do
-      it 'works' do
-        true
+    context 'with no explicit volume-per-connection value' do
+      let(:graph) do
+        Heat.build(tree, list, sources, {})
+      end
+
+      it 'assigns a volume of 10kWh per connection' do
+        # 10kWh * 4 (15 minute frames) * 10 (units)
+        expect(park.buffer_tech.reserves.first.volume).to eql(400.0)
+      end
+
+      it 'assigns an amplified volume of 17.78kWh per connection' do
+        expect(park.buffer_tech.reserves.first.high_volume).to eql(400.0 * 1.78)
+      end
+    end
+
+    context 'an a volume-per-connection of 15kW' do
+      let(:graph) do
+        Heat.build(tree, list, sources, central_heat_buffer_capacity: 15.0)
+      end
+
+      it 'assigns a volume of 15kWh per connection' do
+        # 15kWh * 4 (15 minute frames) * 10 (units)
+        expect(park.buffer_tech.reserves.first.volume).to eql(600.0)
+      end
+
+      it 'assigns an amplified volume of 26.67kWh per connection' do
+        expect(park.buffer_tech.reserves.first.high_volume).to eql(600.0 * 1.78)
       end
     end
   end # Heat


### PR DESCRIPTION
This PR adds an input on the testing ground "general" form allowing the visitor to customise the central heat buffer volume per heat-connection. Defaults to `nil/NULL`, which in turn will default to 10kWh in `Network::Builders::Heat` (so that if we change the default in the future, older LESes won't be stuck with an out-of-date value).

![screen shot 2016-10-24 at 14 25 50](https://cloud.githubusercontent.com/assets/4383/19647405/cd35fa30-99f5-11e6-8b92-206343224cf9.png) ![screen shot 2016-10-24 at 14 25 59](https://cloud.githubusercontent.com/assets/4383/19647407/cf690482-99f5-11e6-95af-530d1a25e680.png)

I think this field would be more at home on the "Heat source list" tab, but I'm not sure if that's possible? All the fields on that page relate to the heat source list, while this is a column on the `testing_grounds` table. I think this is not a deal-breaker.

@grdw Can you take a look at this when you have the time? Thanks!

Ping @ChaelKruip