### PR TITLE
Fix must-run heat sources with no profile

### DIFF
--- a/db/migrate/20161130123307_fix_heat_must_run_profile_assignments.rb
+++ b/db/migrate/20161130123307_fix_heat_must_run_profile_assignments.rb
@@ -1,0 +1,27 @@
+class FixHeatMustRunProfileAssignments < ActiveRecord::Migration
+  def up
+    profile = LoadProfile.where(key: 'constant').first!
+
+    TestingGround.find_each do |les|
+      update_needed = false
+      source_list = les.heat_source_list
+
+      # Old LESes may not have a heat source list.
+      next unless source_list
+
+      decorated = HeatSourceListDecorator.new(les.heat_source_list).decorate
+
+      decorated.each do |tech|
+        next if tech.dispatchable? || tech.profile
+
+        tech.profile = profile.id
+        update_needed = true
+      end
+
+      if update_needed
+        source_list.update_attributes!(asset_list: decorated.map(&:attributes))
+        puts "Updated heat source list for LES #{ les.id }"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027142125) do
+ActiveRecord::Schema.define(version: 20161130123307) do
 
   create_table "asset_lists", force: true do |t|
     t.integer  "testing_ground_id"


### PR DESCRIPTION
Migrates some older LESes which have a must-run heat source without a profile assigned. These LESes would fail to calculate because it is not expected that a must-run would have no profile.

This is the cause of the numerous Airbrake errors:

```
NoMethodError: undefined method `[]' for nil:NilClass

app/models/network/builders/heat.rb:104 in block in sources_to_producers
app/models/network/builders/heat.rb:101 in map
app/models/network/builders/heat.rb:101 in sources_to_producers
app/models/network/builders/heat.rb:32 in build_graph
app/models/network/builders/heat.rb:16 in to_graph
app/models/network/builders/heat.rb:12 in build
app/models/testing_ground.rb:122 in network
...
```

I can't find any way to trigger the missing profile on any new LES, so perhaps it has been inadvertently fixed with some other commit; the most recent affected LES was created more than a month ago.