### PR TITLE
Consume conserved PV loads using sub-path

### DIFF
--- a/app/models/calculation/pull_consumption.rb
+++ b/app/models/calculation/pull_consumption.rb
@@ -89,7 +89,9 @@ module Calculation
           exceedance = path.production_exceedance_at(frame)
           amount     = conservable < exceedance ? conservable : exceedance
 
-          path.consume(frame, amount, true)
+          # Consume on the full-length path. Use the first sub-path so that
+          # technology loads are correctly updated.
+          path.sub_paths.first.consume(frame, amount, true)
         end
       end
     end


### PR DESCRIPTION
Fixes that conserved PV production was not removed from the tech-load (#1590). Sadly there are no tests for this part of the calculation (:disappointed:), but I have checked manually:

| Before | After |
| :---: | :---: |
| <img width="547" alt="screen shot 2017-01-06 at 11 56 13" src="https://cloud.githubusercontent.com/assets/4383/21717167/2593d850-d407-11e6-8bf5-9d4e715c3ce2.png"> | <img width="549" alt="screen shot 2017-01-06 at 11 52 22" src="https://cloud.githubusercontent.com/assets/4383/21717117/df560142-d406-11e6-88b8-3a92a7afa814.png"> |