### PR TITLE
Add technology uglifier for LES's

### DIFF
--- a/app/models/installed_technology.rb
+++ b/app/models/installed_technology.rb
@@ -286,7 +286,10 @@ class InstalledTechnology
   end
 
   def to_h
-    super.delete_if { |_, v| v.blank? }
+    tech = super.delete_if { |_, v| v.blank? }
+    tech[:associates] = (tech[:associates] || []).map(&:to_h)
+    tech[:components] = (tech[:components] || []).map(&:to_h)
+    tech
   end
 
   private

--- a/app/models/technology_list.rb
+++ b/app/models/technology_list.rb
@@ -46,11 +46,9 @@ class TechnologyList
   #
   # Returns a hash.
   def self.dump(list)
-    JSON.dump(Hash[list.to_h.map do |key, techs|
-      [ key, techs.map(&:to_h).map do |tech|
-        tech.update(components: (tech[:components] || []).map(&:to_h))
-      end ]
-    end])
+    JSON.dump(list.each_with_object({}) do |(key, techs), obj|
+      obj[key] = techs.map(&:to_h)
+    end)
   end
 
   # Public: Given a CSV file as a string, creates a TechnologyList.


### PR DESCRIPTION
This seems to work locally:

![screen shot 2018-02-02 at 15 40 26](https://user-images.githubusercontent.com/2676542/35738531-6c71dbf2-082f-11e8-88ad-7f33c2783997.png)

However, if I try to save it (it does save):

Something goes wrong at ETEngine (for `api/v3/scenarios/<scenario-id>/converters/stats`):

![screen shot 2018-02-02 at 15 41 01](https://user-images.githubusercontent.com/2676542/35738561-81fc8e22-082f-11e8-9881-b0e443c036bd.png)

Seems that strong parameters is needed for this to work. 🤔 