### PR TITLE
Fix fetching stats for a single converter

### DIFF
--- a/lib/et_engine_connector.rb
+++ b/lib/et_engine_connector.rb
@@ -20,8 +20,17 @@ class EtEngineConnector
 
   def stats(scenario_id)
     url = ETM_URLS[:stats] % [@provider, scenario_id]
+    params = @params
 
-    et_api_request(:post, url, @params, HEADERS)
+    if params.key?(:keys) && params[:keys].is_a?(Array)
+      # 'stats' wants a hash of keys and attributes to fetch. If the caller does
+      # not care about specific attributes, request all.
+      #
+      # { keys: [:a, :b] } becomes { keys: { a: nil, b: nil } }
+      params = params.merge(keys: Hash[params[:keys].zip([])])
+    end
+
+    et_api_request(:post, url, params, HEADERS)
   end
 
   def scenario(scenario_id)

--- a/spec/controllers/testing_grounds_controller_spec.rb
+++ b/spec/controllers/testing_grounds_controller_spec.rb
@@ -474,7 +474,7 @@ RSpec.describe TestingGroundsController do
     let!(:user) { FactoryGirl.create(:user) }
     let!(:sign_in_user){ sign_in(user) }
     let!(:stub_et_engine) {
-      stub_et_engine_request(keys = ['households_solar_pv_solar_radiation'])
+      stub_et_engine_request({ 'households_solar_pv_solar_radiation' => nil })
     }
 
     let!(:render_template) {


### PR DESCRIPTION
Fixes `EtEngineConnector` to request all converter attributes when `keys` is an array. Fixes the technology selector which currently fails to fetch the attributes:

![screen shot 2018-04-03 at 20 39 11](https://user-images.githubusercontent.com/4383/38271790-4fa4e904-377f-11e8-898d-c6bf394fd20c.png)

Ref: [Airbrake](https://quintel.airbrake.io/projects/35333/groups/2184964795887801140?tab=overview)